### PR TITLE
Add block search command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The `--synced-pattern` filter matches reusable block references by synced patter
 	[--<field>=<value>]
 		One or more args to pass to WP_Query.
 
+		Use native WP_Query pagination args like `--posts_per_page=<n>` and `--paged=<n>` to scan large sites in smaller batches. These args limit the candidate posts examined for a given run; they do not add pagination metadata to the command output.
+
 	[--field=<field>]
 		Prints the value of a single field for each matching post.
 
@@ -151,6 +153,9 @@ These fields are optionally available:
 
 	# Limit the candidate posts scanned with a native query argument.
 	$ wp block search --block=core/paragraph --showposts=50 --format=ids
+
+	# Scan the second batch of 100 candidate posts without changing output format.
+	$ wp block search --block=core/paragraph --posts_per_page=100 --paged=2 --format=ids
 
 	# Restrict search to specific posts and return the match count.
 	$ wp block search --style=rounded --post__in=21,42,84 --format=count

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ wp block
     $ wp block type list
 
     # Find posts that use a rounded block style
-	$ wp block search --style=rounded
+    $ wp block search --style=rounded
 
     # Get a specific block pattern
     $ wp block pattern get my-theme/hero

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The `--synced-pattern` filter matches reusable block references by synced patter
 	[--<field>=<value>]
 		One or more args to pass to WP_Query.
 
-		Use native WP_Query pagination args like `--posts_per_page=<n>` and `--paged=<n>` to scan large sites in smaller batches. These args limit the candidate posts examined for a given run; they do not add pagination metadata to the command output.
+		Use native WP_Query pagination args `--posts_per_page=<n>` and `--paged=<n>` to scan large sites in smaller batches. These args limit the candidate posts examined for a given run; they do not add pagination metadata to the command output. Results in each page may not be equal and empty response isn't guarantee that next page won't have results.
 
 	[--field=<field>]
 		Prints the value of a single field for each matching post.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ wp block
     # List all registered block types
     $ wp block type list
 
+    # Find posts that use a rounded block style
+	$ wp block search --style=rounded
+
     # Get a specific block pattern
     $ wp block pattern get my-theme/hero
 
@@ -35,6 +38,123 @@ wp block
 
     # Create a synced pattern
     $ wp block synced-pattern create --title="My Pattern" --content='<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->'
+
+
+
+### wp block search
+
+Searches posts for block usage.
+
+~~~
+wp block search [--block=<block-name>] [--block-namespace=<block-namespace>] [--style=<style-name>] [--pattern=<pattern-name>] [--pattern-namespace=<pattern-namespace>] [--synced-pattern=<post-id>] [--<field>=<value>] [--field=<field>] [--fields=<fields>] [--format=<format>]
+~~~
+
+Returns matching posts where the requested block appears anywhere in the
+parsed block tree, including nested blocks.
+
+At least one search filter is required: `--block`, `--block-namespace`, `--style`, `--pattern`, `--pattern-namespace`, or `--synced-pattern`.
+
+Pattern filters match embedded block metadata stored in `metadata.patternName`.
+
+The `--synced-pattern` filter matches reusable block references by synced pattern post ID.
+
+**OPTIONS**
+
+	[--block=<block-name>]
+		Block type name to search for (for example, 'core/paragraph').
+
+	[--block-namespace=<block-namespace>]
+		Limit matches to blocks within a specific namespace (for example, 'core').
+
+	[--style=<style-name>]
+		Limit matches to blocks using a specific block style.
+
+	[--pattern=<pattern-name>]
+		Limit matches to blocks embedded from a specific pattern (for example, 'twentytwentyfive/event-rsvp').
+
+	[--pattern-namespace=<pattern-namespace>]
+		Limit matches to blocks embedded from patterns within a specific namespace (for example, 'twentytwentyfive').
+
+	[--synced-pattern=<post-id>]
+		Limit matches to reusable block references for a specific synced pattern post ID.
+
+	Note: `--block` and `--block-namespace` are mutually exclusive. `--pattern` and `--pattern-namespace` are also mutually exclusive.
+
+	[--<field>=<value>]
+		One or more args to pass to WP_Query.
+
+	[--field=<field>]
+		Prints the value of a single field for each matching post.
+
+	[--fields=<fields>]
+		Limit the output to specific result fields.
+
+	[--format=<format>]
+		Render output in a particular format.
+		---
+		default: table
+		options:
+		  - table
+		  - csv
+		  - json
+		  - count
+		  - yaml
+		  - ids
+		---
+
+**AVAILABLE FIELDS**
+
+These fields will be displayed by default for each matching post:
+
+* ID
+* post_title
+* post_name
+* post_date
+* post_status
+
+These fields are optionally available:
+
+* post_type
+* url
+* occurrences
+
+**EXAMPLES**
+
+    # Find posts using the paragraph block.
+	$ wp block search --block=core/paragraph
+
+    # Find posts using any block in namespace like 'core'.
+    $ wp block search --block-namespace=core
+
+    # Find posts using any blocks with block style of 'rounded'.
+	$ wp block search --style=rounded
+
+	# Combine namespace and style filters.
+	$ wp block search --block-namespace=core --style=rounded
+
+	# Find posts using blocks embedded from a specific pattern.
+	$ wp block search --pattern=twentytwentyfive/event-rsvp
+
+	# Find posts using blocks embedded from patterns in a specific namespace.
+	$ wp block search --pattern-namespace=twentytwentyfive
+
+	# Find posts using a specific synced pattern.
+	$ wp block search --synced-pattern=123
+
+	# Combine pattern and block filters.
+	$ wp block search --pattern-namespace=twentytwentyfive --block=core/image
+
+	# Limit search to published pages and show selected fields as JSON.
+	$ wp block search --block=core/image --post_type=page --post_status=publish --fields=ID,post_title,occurrences --format=json
+
+	# Restrict search to specific posts and return the match count.
+	$ wp block search --style=rounded --post__in=21,42,84 --format=count
+
+    # Return only matching post IDs.
+	$ wp block search --block=core/paragraph --format=ids
+
+    # Return count of matching posts.
+	$ wp block search --block=core/heading --format=count
 
 
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ wp block search [--block=<block-name>] [--block-namespace=<block-namespace>] [--
 Returns matching posts where the requested block appears anywhere in the
 parsed block tree, including nested blocks.
 
+To reduce unnecessary parsing on large datasets, the command first applies a coarse `post_content` prefilter when a safe marker is available, then confirms matches by parsing blocks.
+
 At least one search filter is required: `--block`, `--block-namespace`, `--style`, `--pattern`, `--pattern-namespace`, or `--synced-pattern`.
 
 Pattern filters match embedded block metadata stored in `metadata.patternName`.
@@ -146,6 +148,9 @@ These fields are optionally available:
 
 	# Limit search to published pages and show selected fields as JSON.
 	$ wp block search --block=core/image --post_type=page --post_status=publish --fields=ID,post_title,occurrences --format=json
+
+	# Limit the candidate posts scanned with a native query argument.
+	$ wp block search --block=core/paragraph --showposts=50 --format=ids
 
 	# Restrict search to specific posts and return the match count.
 	$ wp block search --style=rounded --post__in=21,42,84 --format=count

--- a/block-command.php
+++ b/block-command.php
@@ -54,3 +54,4 @@ WP_CLI::add_command( 'block style', WP_CLI\Block\Block_Style_Command::class, [ '
 WP_CLI::add_command( 'block binding', WP_CLI\Block\Block_Binding_Command::class, [ 'before_invoke' => $wpcli_block_before_invoke_6_5 ] );
 WP_CLI::add_command( 'block template', WP_CLI\Block\Block_Template_Command::class, [ 'before_invoke' => $wpcli_block_before_invoke_5_9 ] );
 WP_CLI::add_command( 'block synced-pattern', WP_CLI\Block\Block_Synced_Pattern_Command::class, [ 'before_invoke' => $wpcli_block_before_invoke_5_0 ] );
+WP_CLI::add_command( 'block search', WP_CLI\Block\Block_Search_Command::class, [ 'before_invoke' => $wpcli_block_before_invoke_5_0 ] );

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "bundled": true,
     "commands": [
       "block",
+      "block search",
       "block type",
       "block type exists",
       "block type list",

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     "wp-cli/wp-cli": "^2.13"
   },
   "require-dev": {
+    "wp-cli/entity-command": "^1.3 || ^2",
     "wp-cli/extension-command": "^2",
     "wp-cli/wp-cli-tests": "^5"
   },

--- a/features/block-search.feature
+++ b/features/block-search.feature
@@ -5,7 +5,11 @@ Feature: Search posts by block usage
     Given a WP install
 
   Scenario: Search posts by block type usage
-    When I run `wp post --post_type=post create --post_title='Quote Post' --post_status=publish --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Hello world</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Given a quote-post.html file:
+      """
+      <!-- wp:quote --><blockquote class="wp-block-quote"><p>Hello world</p></blockquote><!-- /wp:quote -->
+      """
+    When I run `wp post create quote-post.html --post_type=post --post_title='Quote Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {QUOTE_POST_ID}
 
@@ -16,7 +20,11 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search posts by block namespace
-    When I run `wp post --post_type=post create --post_title='Core Namespace Post' --post_status=publish --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Hello core</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Given a core-namespace-post.html file:
+      """
+      <!-- wp:quote --><blockquote class="wp-block-quote"><p>Hello core</p></blockquote><!-- /wp:quote -->
+      """
+    When I run `wp post create core-namespace-post.html --post_type=post --post_title='Core Namespace Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {CORE_NAMESPACE_POST_ID}
 
@@ -27,7 +35,11 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search nested block usage
-    When I run `wp post --post_type=page create --post_title='Nested Image Post' --post_status=publish --post_content='<!-- wp:group --><div class="wp-block-group"><!-- wp:image {"sizeSlug":"large"} --><figure class="wp-block-image size-large"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group -->' --porcelain`
+    Given a nested-image-post.html file:
+      """
+      <!-- wp:group --><div class="wp-block-group"><!-- wp:image {"sizeSlug":"large"} --><figure class="wp-block-image size-large"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group -->
+      """
+    When I run `wp post create nested-image-post.html --post_type=page --post_title='Nested Image Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {NESTED_POST_ID}
 
@@ -38,14 +50,26 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search block usage by style
-    When I run `wp post --post_type=post create --post_title='Rounded Image Post' --post_status=publish --post_content='<!-- wp:image {"className":"is-style-rounded"} --><figure class="wp-block-image is-style-rounded"><img alt="" /></figure><!-- /wp:image -->' --porcelain`
+    Given a rounded-image-post.html file:
+      """
+      <!-- wp:image {"className":"is-style-rounded"} --><figure class="wp-block-image is-style-rounded"><img alt="" /></figure><!-- /wp:image -->
+      """
+    When I run `wp post create rounded-image-post.html --post_type=post --post_title='Rounded Image Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {ROUNDED_IMAGE_POST_ID}
 
-    When I run `wp post --post_type=post create --post_title='Plain Image Post' --post_status=publish --post_content='<!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image -->' --porcelain`
+    Given a plain-image-post.html file:
+      """
+      <!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image -->
+      """
+    When I run `wp post create plain-image-post.html --post_type=post --post_title='Plain Image Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
 
-    When I run `wp post --post_type=post create --post_title='Rounded Quote Post' --post_status=publish --post_content='<!-- wp:quote {"className":"is-style-rounded"} --><blockquote class="wp-block-quote is-style-rounded"><p>Hello quote</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Given a rounded-quote-post.html file:
+      """
+      <!-- wp:quote {"className":"is-style-rounded"} --><blockquote class="wp-block-quote is-style-rounded"><p>Hello quote</p></blockquote><!-- /wp:quote -->
+      """
+    When I run `wp post create rounded-quote-post.html --post_type=post --post_title='Rounded Quote Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {ROUNDED_QUOTE_POST_ID}
 
@@ -67,11 +91,19 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search block usage count
-    When I run `wp post --post_type=post create --post_title='Counted Quote One' --post_status=publish --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>One</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Given a counted-quote-one.html file:
+      """
+      <!-- wp:quote --><blockquote class="wp-block-quote"><p>One</p></blockquote><!-- /wp:quote -->
+      """
+    When I run `wp post create counted-quote-one.html --post_type=post --post_title='Counted Quote One' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {COUNTED_QUOTE_ONE_ID}
 
-    When I run `wp post --post_type=post create --post_title='Counted Quote Two' --post_status=publish --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Two</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Given a counted-quote-two.html file:
+      """
+      <!-- wp:quote --><blockquote class="wp-block-quote"><p>Two</p></blockquote><!-- /wp:quote -->
+      """
+    When I run `wp post create counted-quote-two.html --post_type=post --post_title='Counted Quote Two' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {COUNTED_QUOTE_TWO_ID}
 
@@ -93,7 +125,11 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search block usage with selected fields in JSON
-    When I run `wp post --post_type=post create --post_title='Double Quote Post' --post_status=publish --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>One</p></blockquote><!-- /wp:quote --><!-- wp:quote --><blockquote class="wp-block-quote"><p>Two</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Given a double-quote-post.html file:
+      """
+      <!-- wp:quote --><blockquote class="wp-block-quote"><p>One</p></blockquote><!-- /wp:quote --><!-- wp:quote --><blockquote class="wp-block-quote"><p>Two</p></blockquote><!-- /wp:quote -->
+      """
+    When I run `wp post create double-quote-post.html --post_type=post --post_title='Double Quote Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {DOUBLE_QUOTE_POST_ID}
 
@@ -104,11 +140,19 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search blocks embedded from a specific pattern
-    When I run `wp post --post_type=post create --post_title='Pattern RSVP Post' --post_status=publish --post_content='<!-- wp:group {"metadata":{"categories":["call-to-action"],"patternName":"twentytwentyfive/event-rsvp","name":"Event RSVP"}} --><div class="wp-block-group"><!-- wp:paragraph --><p>RSVP now</p><!-- /wp:paragraph --></div><!-- /wp:group -->' --porcelain`
+    Given a pattern-rsvp-post.html file:
+      """
+      <!-- wp:group {"metadata":{"categories":["call-to-action"],"patternName":"twentytwentyfive/event-rsvp","name":"Event RSVP"}} --><div class="wp-block-group"><!-- wp:paragraph --><p>RSVP now</p><!-- /wp:paragraph --></div><!-- /wp:group -->
+      """
+    When I run `wp post create pattern-rsvp-post.html --post_type=post --post_title='Pattern RSVP Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {PATTERN_RSVP_POST_ID}
 
-    When I run `wp post --post_type=post create --post_title='Pattern Header Post' --post_status=publish --post_content='<!-- wp:group {"metadata":{"categories":["header"],"patternName":"twentytwentyfive/site-header","name":"Site Header"}} --><div class="wp-block-group"><!-- wp:paragraph --><p>Header block</p><!-- /wp:paragraph --></div><!-- /wp:group -->' --porcelain`
+    Given a pattern-header-post.html file:
+      """
+      <!-- wp:group {"metadata":{"categories":["header"],"patternName":"twentytwentyfive/site-header","name":"Site Header"}} --><div class="wp-block-group"><!-- wp:paragraph --><p>Header block</p><!-- /wp:paragraph --></div><!-- /wp:group -->
+      """
+    When I run `wp post create pattern-header-post.html --post_type=post --post_title='Pattern Header Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {PATTERN_HEADER_POST_ID}
 
@@ -136,7 +180,11 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search pattern blocks with an additional block filter
-    When I run `wp post --post_type=post create --post_title='Patterned Image Post' --post_status=publish --post_content='<!-- wp:group {"metadata":{"categories":["media"],"patternName":"twentytwentyfive/media-highlight","name":"Media Highlight"}} --><div class="wp-block-group"><!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group -->' --porcelain`
+    Given a patterned-image-post.html file:
+      """
+      <!-- wp:group {"metadata":{"categories":["media"],"patternName":"twentytwentyfive/media-highlight","name":"Media Highlight"}} --><div class="wp-block-group"><!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group -->
+      """
+    When I run `wp post create patterned-image-post.html --post_type=post --post_title='Patterned Image Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {PATTERN_IMAGE_POST_ID}
 
@@ -147,7 +195,11 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search uses the nearest pattern ancestor for nested patterns
-    When I run `wp post --post_type=post create --post_title='Nested Pattern Image Post' --post_status=publish --post_content='<!-- wp:group {"metadata":{"categories":["outer"],"patternName":"twentytwentyfive/outer-shell","name":"Outer Shell"}} --><div class="wp-block-group"><!-- wp:group {"metadata":{"categories":["inner"],"patternName":"twentytwentyfive/inner-media","name":"Inner Media"}} --><div class="wp-block-group"><!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group --></div><!-- /wp:group -->' --porcelain`
+    Given a nested-pattern-image-post.html file:
+      """
+      <!-- wp:group {"metadata":{"categories":["outer"],"patternName":"twentytwentyfive/outer-shell","name":"Outer Shell"}} --><div class="wp-block-group"><!-- wp:group {"metadata":{"categories":["inner"],"patternName":"twentytwentyfive/inner-media","name":"Inner Media"}} --><div class="wp-block-group"><!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group --></div><!-- /wp:group -->
+      """
+    When I run `wp post create nested-pattern-image-post.html --post_type=post --post_title='Nested Pattern Image Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {NESTED_PATTERN_IMAGE_POST_ID}
 
@@ -172,11 +224,21 @@ Feature: Search posts by block usage
     Then STDOUT should be a number
     And save STDOUT as {SYNCED_PATTERN_ID}
 
-    When I run `wp post --post_type=post create --post_title='Reusable Pattern Post' --post_status=publish --post_content='<!-- wp:block {"ref":{SYNCED_PATTERN_ID}} /-->' --porcelain`
+    When I run `wp post create --post_type=post --post_title='Reusable Pattern Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {SYNCED_PATTERN_POST_ID}
 
-    When I run `wp post --post_type=post create --post_title='Different Reusable Pattern Post' --post_status=publish --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Not reusable</p></blockquote><!-- /wp:quote -->' --porcelain`
+    When I run `wp post block insert {SYNCED_PATTERN_POST_ID} core/block --attrs='{"ref":{SYNCED_PATTERN_ID}}'`
+    Then STDOUT should contain:
+      """
+      Success: Inserted block into post {SYNCED_PATTERN_POST_ID}.
+      """
+
+    Given a different-reusable-pattern-post.html file:
+      """
+      <!-- wp:quote --><blockquote class="wp-block-quote"><p>Not reusable</p></blockquote><!-- /wp:quote -->
+      """
+    When I run `wp post create different-reusable-pattern-post.html --post_type=post --post_title='Different Reusable Pattern Post' --post_status=publish --porcelain`
     Then STDOUT should be a number
 
     When I run `wp block search --synced-pattern={SYNCED_PATTERN_ID} --field=ID`

--- a/features/block-search.feature
+++ b/features/block-search.feature
@@ -165,6 +165,35 @@ Feature: Search posts by block usage
       [{"ID":{DOUBLE_QUOTE_POST_ID},"occurrences":2}]
       """
 
+  Scenario: Search block usage with WP_Query pagination arguments
+    Given a paged-first-post.html file:
+      """
+      <!-- wp:quote --><blockquote class="wp-block-quote"><p>First paged match</p></blockquote><!-- /wp:quote -->
+      """
+    When I run `wp post create paged-first-post.html --post_type=post --post_title='A Paged Match' --post_status=publish --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {PAGED_FIRST_POST_ID}
+
+    Given a paged-second-post.html file:
+      """
+      <!-- wp:quote --><blockquote class="wp-block-quote"><p>Second paged match</p></blockquote><!-- /wp:quote -->
+      """
+    When I run `wp post create paged-second-post.html --post_type=post --post_title='B Paged Match' --post_status=publish --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {PAGED_SECOND_POST_ID}
+
+    When I run `wp block search --block=core/quote --post_type=post --orderby=title --order=ASC --posts_per_page=1 --paged=1 --field=ID`
+    Then STDOUT should be:
+      """
+      {PAGED_FIRST_POST_ID}
+      """
+
+    When I run `wp block search --block=core/quote --post_type=post --orderby=title --order=ASC --posts_per_page=1 --paged=2 --field=ID`
+    Then STDOUT should be:
+      """
+      {PAGED_SECOND_POST_ID}
+      """
+
   Scenario: Search blocks embedded from a specific pattern
     Given a pattern-rsvp-post.html file:
       """

--- a/features/block-search.feature
+++ b/features/block-search.feature
@@ -34,6 +34,21 @@ Feature: Search posts by block usage
       {CORE_NAMESPACE_POST_ID}
       """
 
+  Scenario: Search posts by custom block namespace
+    Given a custom-namespace-post.html file:
+      """
+      <!-- wp:my-plugin/card --><div class="wp-block-my-plugin-card">Hello custom</div><!-- /wp:my-plugin/card -->
+      """
+    When I run `wp post create custom-namespace-post.html --post_type=post --post_title='Custom Namespace Post' --post_status=publish --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {CUSTOM_NAMESPACE_POST_ID}
+
+    When I run `wp block search --block-namespace=my-plugin --post_type=post --field=ID`
+    Then STDOUT should be:
+      """
+      {CUSTOM_NAMESPACE_POST_ID}
+      """
+
   Scenario: Search nested block usage
     Given a nested-image-post.html file:
       """
@@ -88,6 +103,17 @@ Feature: Search posts by block usage
     And STDOUT should contain:
       """
       {ROUNDED_QUOTE_POST_ID}
+      """
+
+  Scenario: Style search ignores plain text false positives
+    When I run `wp post create --post_type=post --post_title='Style Token Plain Text Post' --post_status=publish --post_content='This post mentions is-style-rounded in plain text only.' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {STYLE_TOKEN_TEXT_POST_ID}
+
+    When I run `wp block search --style=rounded --field=ID --format=ids`
+    Then STDOUT should not contain:
+      """
+      {STYLE_TOKEN_TEXT_POST_ID}
       """
 
   Scenario: Search block usage count
@@ -156,10 +182,23 @@ Feature: Search posts by block usage
     Then STDOUT should be a number
     And save STDOUT as {PATTERN_HEADER_POST_ID}
 
+    Given a spaced-pattern-rsvp-post.html file:
+      """
+      <!-- wp:group {"metadata":{"categories":["call-to-action"],"patternName": "twentytwentyfive/event-rsvp","name":"Event RSVP Spaced"}} --><div class="wp-block-group"><!-- wp:paragraph --><p>RSVP later</p><!-- /wp:paragraph --></div><!-- /wp:group -->
+      """
+    When I run `wp post create spaced-pattern-rsvp-post.html --post_type=post --post_title='Pattern RSVP Spaced Post' --post_status=publish --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {SPACED_PATTERN_RSVP_POST_ID}
+
     When I run `wp block search --pattern=twentytwentyfive/event-rsvp --field=ID`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       {PATTERN_RSVP_POST_ID}
+      """
+
+    And STDOUT should contain:
+      """
+      {SPACED_PATTERN_RSVP_POST_ID}
       """
 
     When I run `wp block search --pattern=twentytwentyfive/event-rsvp --field=ID --format=ids`
@@ -172,6 +211,11 @@ Feature: Search posts by block usage
     Then STDOUT should contain:
       """
       {PATTERN_RSVP_POST_ID}
+      """
+
+    And STDOUT should contain:
+      """
+      {SPACED_PATTERN_RSVP_POST_ID}
       """
 
     And STDOUT should contain:
@@ -242,7 +286,7 @@ Feature: Search posts by block usage
     Then STDOUT should be a number
 
     When I run `wp block search --synced-pattern={SYNCED_PATTERN_ID} --field=ID`
-    Then STDOUT should be:
+    Then STDOUT should contain:
       """
       {SYNCED_PATTERN_POST_ID}
       """

--- a/features/block-search.feature
+++ b/features/block-search.feature
@@ -1,0 +1,218 @@
+@require-wp-5.0
+Feature: Search posts by block usage
+
+  Background:
+    Given a WP install
+
+  Scenario: Search posts by block type usage
+    When I run `wp post create --post_title='Quote Post' --post_status=publish --post_type=post --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Hello world</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {QUOTE_POST_ID}
+
+    When I run `wp block search --block=core/quote --post_type=post --field=ID`
+    Then STDOUT should be:
+      """
+      {QUOTE_POST_ID}
+      """
+
+  Scenario: Search posts by block namespace
+    When I run `wp post create --post_title='Core Namespace Post' --post_status=publish --post_type=post --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Hello core</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {CORE_NAMESPACE_POST_ID}
+
+    When I run `wp block search --block-namespace=core --post_type=post --field=ID`
+    Then STDOUT should contain:
+      """
+      {CORE_NAMESPACE_POST_ID}
+      """
+
+  Scenario: Search nested block usage
+    When I run `wp post create --post_title='Nested Image Post' --post_status=publish --post_type=page --post_content='<!-- wp:group --><div class="wp-block-group"><!-- wp:image {"sizeSlug":"large"} --><figure class="wp-block-image size-large"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group -->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {NESTED_POST_ID}
+
+    When I run `wp block search --block=core/image --post_type=page --field=ID`
+    Then STDOUT should be:
+      """
+      {NESTED_POST_ID}
+      """
+
+  Scenario: Search block usage by style
+    When I run `wp post create --post_title='Rounded Image Post' --post_status=publish --post_type=post --post_content='<!-- wp:image {"className":"is-style-rounded"} --><figure class="wp-block-image is-style-rounded"><img alt="" /></figure><!-- /wp:image -->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {ROUNDED_IMAGE_POST_ID}
+
+    When I run `wp post create --post_title='Plain Image Post' --post_status=publish --post_type=post --post_content='<!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image -->' --porcelain`
+    Then STDOUT should be a number
+
+    When I run `wp post create --post_title='Rounded Quote Post' --post_status=publish --post_type=post --post_content='<!-- wp:quote {"className":"is-style-rounded"} --><blockquote class="wp-block-quote is-style-rounded"><p>Hello quote</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {ROUNDED_QUOTE_POST_ID}
+
+    When I run `wp block search --block=core/image --style=rounded --field=ID`
+    Then STDOUT should be:
+      """
+      {ROUNDED_IMAGE_POST_ID}
+      """
+
+    When I run `wp block search --style=rounded --field=ID`
+    Then STDOUT should contain:
+      """
+      {ROUNDED_IMAGE_POST_ID}
+      """
+
+    And STDOUT should contain:
+      """
+      {ROUNDED_QUOTE_POST_ID}
+      """
+
+  Scenario: Search block usage count
+    When I run `wp post create --post_title='Counted Quote One' --post_status=publish --post_type=post --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>One</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {COUNTED_QUOTE_ONE_ID}
+
+    When I run `wp post create --post_title='Counted Quote Two' --post_status=publish --post_type=post --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Two</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {COUNTED_QUOTE_TWO_ID}
+
+    When I run `wp block search --block=core/quote --post_type=post --format=count`
+    Then STDOUT should be:
+      """
+      2
+      """
+
+    When I run `wp block search --block=core/quote --post__in={COUNTED_QUOTE_ONE_ID},{COUNTED_QUOTE_TWO_ID} --format=ids`
+    Then STDOUT should contain:
+      """
+      {COUNTED_QUOTE_ONE_ID}
+      """
+
+    And STDOUT should contain:
+      """
+      {COUNTED_QUOTE_TWO_ID}
+      """
+
+  Scenario: Search block usage with selected fields in JSON
+    When I run `wp post create --post_title='Double Quote Post' --post_status=publish --post_type=post --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>One</p></blockquote><!-- /wp:quote --><!-- wp:quote --><blockquote class="wp-block-quote"><p>Two</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {DOUBLE_QUOTE_POST_ID}
+
+    When I run `wp block search --block=core/quote --post__in={DOUBLE_QUOTE_POST_ID} --fields=ID,occurrences --format=json`
+    Then STDOUT should be JSON containing:
+      """
+      [{"ID":{DOUBLE_QUOTE_POST_ID},"occurrences":2}]
+      """
+
+  Scenario: Search blocks embedded from a specific pattern
+    When I run `wp post create --post_title='Pattern RSVP Post' --post_status=publish --post_type=post --post_content='<!-- wp:group {"metadata":{"categories":["call-to-action"],"patternName":"twentytwentyfive/event-rsvp","name":"Event RSVP"}} --><div class="wp-block-group"><!-- wp:paragraph --><p>RSVP now</p><!-- /wp:paragraph --></div><!-- /wp:group -->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {PATTERN_RSVP_POST_ID}
+
+    When I run `wp post create --post_title='Pattern Header Post' --post_status=publish --post_type=post --post_content='<!-- wp:group {"metadata":{"categories":["header"],"patternName":"twentytwentyfive/site-header","name":"Site Header"}} --><div class="wp-block-group"><!-- wp:paragraph --><p>Header block</p><!-- /wp:paragraph --></div><!-- /wp:group -->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {PATTERN_HEADER_POST_ID}
+
+    When I run `wp block search --pattern=twentytwentyfive/event-rsvp --field=ID`
+    Then STDOUT should be:
+      """
+      {PATTERN_RSVP_POST_ID}
+      """
+
+    When I run `wp block search --pattern=twentytwentyfive/event-rsvp --field=ID --format=ids`
+    Then STDOUT should not contain:
+      """
+      {PATTERN_HEADER_POST_ID}
+      """
+
+    When I run `wp block search --pattern-namespace=twentytwentyfive --field=ID`
+    Then STDOUT should contain:
+      """
+      {PATTERN_RSVP_POST_ID}
+      """
+
+    And STDOUT should contain:
+      """
+      {PATTERN_HEADER_POST_ID}
+      """
+
+  Scenario: Search pattern blocks with an additional block filter
+    When I run `wp post create --post_title='Patterned Image Post' --post_status=publish --post_type=post --post_content='<!-- wp:group {"metadata":{"categories":["media"],"patternName":"twentytwentyfive/media-highlight","name":"Media Highlight"}} --><div class="wp-block-group"><!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group -->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {PATTERN_IMAGE_POST_ID}
+
+    When I run `wp block search --pattern-namespace=twentytwentyfive --block=core/image --field=ID`
+    Then STDOUT should be:
+      """
+      {PATTERN_IMAGE_POST_ID}
+      """
+
+  Scenario: Search uses the nearest pattern ancestor for nested patterns
+    When I run `wp post create --post_title='Nested Pattern Image Post' --post_status=publish --post_type=post --post_content='<!-- wp:group {"metadata":{"categories":["outer"],"patternName":"twentytwentyfive/outer-shell","name":"Outer Shell"}} --><div class="wp-block-group"><!-- wp:group {"metadata":{"categories":["inner"],"patternName":"twentytwentyfive/inner-media","name":"Inner Media"}} --><div class="wp-block-group"><!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group --></div><!-- /wp:group -->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {NESTED_PATTERN_IMAGE_POST_ID}
+
+    When I run `wp block search --pattern=twentytwentyfive/inner-media --block=core/image --field=ID`
+    Then STDOUT should be:
+      """
+      {NESTED_PATTERN_IMAGE_POST_ID}
+      """
+
+    When I run `wp block search --pattern=twentytwentyfive/outer-shell --block=core/image --field=ID --format=ids`
+    Then STDOUT should not contain:
+      """
+      {NESTED_PATTERN_IMAGE_POST_ID}
+      """
+
+  Scenario: Search posts by synced pattern reference
+    Given a pattern.html file:
+      """
+      <!-- wp:paragraph --><p>Reusable</p><!-- /wp:paragraph -->
+      """
+    When I run `wp block synced-pattern create pattern.html --title='Reusable Search Pattern' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {SYNCED_PATTERN_ID}
+
+    When I run `wp post create --post_title='Reusable Pattern Post' --post_status=publish --post_type=post --post_content='<!-- wp:block {"ref":{SYNCED_PATTERN_ID}} /-->' --porcelain`
+    Then STDOUT should be a number
+    And save STDOUT as {SYNCED_PATTERN_POST_ID}
+
+    When I run `wp post create --post_title='Different Reusable Pattern Post' --post_status=publish --post_type=post --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Not reusable</p></blockquote><!-- /wp:quote -->' --porcelain`
+    Then STDOUT should be a number
+
+    When I run `wp block search --synced-pattern={SYNCED_PATTERN_ID} --field=ID`
+    Then STDOUT should be:
+      """
+      {SYNCED_PATTERN_POST_ID}
+      """
+
+  Scenario: Pattern and pattern namespace are mutually exclusive
+    When I try `wp block search --pattern=twentytwentyfive/event-rsvp --pattern-namespace=twentytwentyfive`
+    Then STDERR should contain:
+      """
+      The --pattern and --pattern-namespace parameters are mutually exclusive.
+      """
+    And the return code should be 1
+
+  Scenario: Block name and namespace are mutually exclusive
+    When I try `wp block search --block=core/quote --block-namespace=core`
+    Then STDERR should contain:
+      """
+      The --block and --block-namespace parameters are mutually exclusive.
+      """
+    And the return code should be 1
+
+  Scenario: Synced pattern parameter must be a positive integer
+    When I try `wp block search --synced-pattern=0`
+    Then STDERR should contain:
+      """
+      The --synced-pattern parameter must be a positive integer post ID.
+      """
+    And the return code should be 1
+
+  Scenario: Search requires at least one filter
+    When I try `wp block search`
+    Then STDERR should contain:
+      """
+      At least one block filter is required: --block, --block-namespace, --style, --pattern, --pattern-namespace, or --synced-pattern.
+      """
+    And the return code should be 1

--- a/features/block-search.feature
+++ b/features/block-search.feature
@@ -5,7 +5,7 @@ Feature: Search posts by block usage
     Given a WP install
 
   Scenario: Search posts by block type usage
-    When I run `wp post create --post_title='Quote Post' --post_status=publish --post_type=post --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Hello world</p></blockquote><!-- /wp:quote -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Quote Post' --post_status=publish --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Hello world</p></blockquote><!-- /wp:quote -->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {QUOTE_POST_ID}
 
@@ -16,7 +16,7 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search posts by block namespace
-    When I run `wp post create --post_title='Core Namespace Post' --post_status=publish --post_type=post --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Hello core</p></blockquote><!-- /wp:quote -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Core Namespace Post' --post_status=publish --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Hello core</p></blockquote><!-- /wp:quote -->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {CORE_NAMESPACE_POST_ID}
 
@@ -27,7 +27,7 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search nested block usage
-    When I run `wp post create --post_title='Nested Image Post' --post_status=publish --post_type=page --post_content='<!-- wp:group --><div class="wp-block-group"><!-- wp:image {"sizeSlug":"large"} --><figure class="wp-block-image size-large"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group -->' --porcelain`
+    When I run `wp post --post_type=page create --post_title='Nested Image Post' --post_status=publish --post_content='<!-- wp:group --><div class="wp-block-group"><!-- wp:image {"sizeSlug":"large"} --><figure class="wp-block-image size-large"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group -->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {NESTED_POST_ID}
 
@@ -38,14 +38,14 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search block usage by style
-    When I run `wp post create --post_title='Rounded Image Post' --post_status=publish --post_type=post --post_content='<!-- wp:image {"className":"is-style-rounded"} --><figure class="wp-block-image is-style-rounded"><img alt="" /></figure><!-- /wp:image -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Rounded Image Post' --post_status=publish --post_content='<!-- wp:image {"className":"is-style-rounded"} --><figure class="wp-block-image is-style-rounded"><img alt="" /></figure><!-- /wp:image -->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {ROUNDED_IMAGE_POST_ID}
 
-    When I run `wp post create --post_title='Plain Image Post' --post_status=publish --post_type=post --post_content='<!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Plain Image Post' --post_status=publish --post_content='<!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image -->' --porcelain`
     Then STDOUT should be a number
 
-    When I run `wp post create --post_title='Rounded Quote Post' --post_status=publish --post_type=post --post_content='<!-- wp:quote {"className":"is-style-rounded"} --><blockquote class="wp-block-quote is-style-rounded"><p>Hello quote</p></blockquote><!-- /wp:quote -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Rounded Quote Post' --post_status=publish --post_content='<!-- wp:quote {"className":"is-style-rounded"} --><blockquote class="wp-block-quote is-style-rounded"><p>Hello quote</p></blockquote><!-- /wp:quote -->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {ROUNDED_QUOTE_POST_ID}
 
@@ -67,11 +67,11 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search block usage count
-    When I run `wp post create --post_title='Counted Quote One' --post_status=publish --post_type=post --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>One</p></blockquote><!-- /wp:quote -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Counted Quote One' --post_status=publish --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>One</p></blockquote><!-- /wp:quote -->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {COUNTED_QUOTE_ONE_ID}
 
-    When I run `wp post create --post_title='Counted Quote Two' --post_status=publish --post_type=post --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Two</p></blockquote><!-- /wp:quote -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Counted Quote Two' --post_status=publish --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Two</p></blockquote><!-- /wp:quote -->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {COUNTED_QUOTE_TWO_ID}
 
@@ -93,7 +93,7 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search block usage with selected fields in JSON
-    When I run `wp post create --post_title='Double Quote Post' --post_status=publish --post_type=post --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>One</p></blockquote><!-- /wp:quote --><!-- wp:quote --><blockquote class="wp-block-quote"><p>Two</p></blockquote><!-- /wp:quote -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Double Quote Post' --post_status=publish --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>One</p></blockquote><!-- /wp:quote --><!-- wp:quote --><blockquote class="wp-block-quote"><p>Two</p></blockquote><!-- /wp:quote -->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {DOUBLE_QUOTE_POST_ID}
 
@@ -104,11 +104,11 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search blocks embedded from a specific pattern
-    When I run `wp post create --post_title='Pattern RSVP Post' --post_status=publish --post_type=post --post_content='<!-- wp:group {"metadata":{"categories":["call-to-action"],"patternName":"twentytwentyfive/event-rsvp","name":"Event RSVP"}} --><div class="wp-block-group"><!-- wp:paragraph --><p>RSVP now</p><!-- /wp:paragraph --></div><!-- /wp:group -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Pattern RSVP Post' --post_status=publish --post_content='<!-- wp:group {"metadata":{"categories":["call-to-action"],"patternName":"twentytwentyfive/event-rsvp","name":"Event RSVP"}} --><div class="wp-block-group"><!-- wp:paragraph --><p>RSVP now</p><!-- /wp:paragraph --></div><!-- /wp:group -->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {PATTERN_RSVP_POST_ID}
 
-    When I run `wp post create --post_title='Pattern Header Post' --post_status=publish --post_type=post --post_content='<!-- wp:group {"metadata":{"categories":["header"],"patternName":"twentytwentyfive/site-header","name":"Site Header"}} --><div class="wp-block-group"><!-- wp:paragraph --><p>Header block</p><!-- /wp:paragraph --></div><!-- /wp:group -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Pattern Header Post' --post_status=publish --post_content='<!-- wp:group {"metadata":{"categories":["header"],"patternName":"twentytwentyfive/site-header","name":"Site Header"}} --><div class="wp-block-group"><!-- wp:paragraph --><p>Header block</p><!-- /wp:paragraph --></div><!-- /wp:group -->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {PATTERN_HEADER_POST_ID}
 
@@ -136,7 +136,7 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search pattern blocks with an additional block filter
-    When I run `wp post create --post_title='Patterned Image Post' --post_status=publish --post_type=post --post_content='<!-- wp:group {"metadata":{"categories":["media"],"patternName":"twentytwentyfive/media-highlight","name":"Media Highlight"}} --><div class="wp-block-group"><!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Patterned Image Post' --post_status=publish --post_content='<!-- wp:group {"metadata":{"categories":["media"],"patternName":"twentytwentyfive/media-highlight","name":"Media Highlight"}} --><div class="wp-block-group"><!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group -->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {PATTERN_IMAGE_POST_ID}
 
@@ -147,7 +147,7 @@ Feature: Search posts by block usage
       """
 
   Scenario: Search uses the nearest pattern ancestor for nested patterns
-    When I run `wp post create --post_title='Nested Pattern Image Post' --post_status=publish --post_type=post --post_content='<!-- wp:group {"metadata":{"categories":["outer"],"patternName":"twentytwentyfive/outer-shell","name":"Outer Shell"}} --><div class="wp-block-group"><!-- wp:group {"metadata":{"categories":["inner"],"patternName":"twentytwentyfive/inner-media","name":"Inner Media"}} --><div class="wp-block-group"><!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group --></div><!-- /wp:group -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Nested Pattern Image Post' --post_status=publish --post_content='<!-- wp:group {"metadata":{"categories":["outer"],"patternName":"twentytwentyfive/outer-shell","name":"Outer Shell"}} --><div class="wp-block-group"><!-- wp:group {"metadata":{"categories":["inner"],"patternName":"twentytwentyfive/inner-media","name":"Inner Media"}} --><div class="wp-block-group"><!-- wp:image --><figure class="wp-block-image"><img alt="" /></figure><!-- /wp:image --></div><!-- /wp:group --></div><!-- /wp:group -->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {NESTED_PATTERN_IMAGE_POST_ID}
 
@@ -172,11 +172,11 @@ Feature: Search posts by block usage
     Then STDOUT should be a number
     And save STDOUT as {SYNCED_PATTERN_ID}
 
-    When I run `wp post create --post_title='Reusable Pattern Post' --post_status=publish --post_type=post --post_content='<!-- wp:block {"ref":{SYNCED_PATTERN_ID}} /-->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Reusable Pattern Post' --post_status=publish --post_content='<!-- wp:block {"ref":{SYNCED_PATTERN_ID}} /-->' --porcelain`
     Then STDOUT should be a number
     And save STDOUT as {SYNCED_PATTERN_POST_ID}
 
-    When I run `wp post create --post_title='Different Reusable Pattern Post' --post_status=publish --post_type=post --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Not reusable</p></blockquote><!-- /wp:quote -->' --porcelain`
+    When I run `wp post --post_type=post create --post_title='Different Reusable Pattern Post' --post_status=publish --post_content='<!-- wp:quote --><blockquote class="wp-block-quote"><p>Not reusable</p></blockquote><!-- /wp:quote -->' --porcelain`
     Then STDOUT should be a number
 
     When I run `wp block search --synced-pattern={SYNCED_PATTERN_ID} --field=ID`

--- a/src/Block_Command.php
+++ b/src/Block_Command.php
@@ -11,6 +11,9 @@ use WP_CLI\Dispatcher\CommandNamespace;
  *
  *     # List all registered block types
  *     $ wp block type list
+
+ *     # Find posts by block usage
+ *     $ wp block search --block=core/button
  *
  *     # Get a specific block pattern
  *     $ wp block pattern get my-theme/hero

--- a/src/Block_Command.php
+++ b/src/Block_Command.php
@@ -11,7 +11,7 @@ use WP_CLI\Dispatcher\CommandNamespace;
  *
  *     # List all registered block types
  *     $ wp block type list
-
+ *
  *     # Find posts by block usage
  *     $ wp block search --block=core/button
  *

--- a/src/Block_Search_Command.php
+++ b/src/Block_Search_Command.php
@@ -106,6 +106,9 @@ use WP_CLI_Command;
  *     # Show selected fields as JSON for further processing.
  *     $ wp block search --block=core/heading --post_status=publish --fields=ID,post_type,occurrences --format=json
  *
+ *     # Limit the candidate posts scanned with a native query argument.
+ *     $ wp block search --block=core/paragraph --showposts=50 --format=ids
+ *
  *     # Restrict search to specific posts and return the count.
  *     $ wp block search --style=rounded --post__in=21,42,84 --format=count
  *
@@ -187,8 +190,17 @@ class Block_Search_Command extends WP_CLI_Command {
 			$query_args['post_type'] = explode( ',', $query_args['post_type'] );
 		}
 
+		$rough_prefilter = $this->build_rough_post_content_prefilter(
+			$block_name,
+			$block_namespace,
+			$style_name,
+			$pattern_name,
+			$pattern_ns,
+			$synced_pattern
+		);
+
 		$results = [];
-		$query   = new \WP_Query( $query_args );
+		$query   = $this->run_query_with_rough_prefilter( $query_args, $rough_prefilter );
 
 		foreach ( $query->posts as $post ) {
 			if ( ! $post instanceof \WP_Post ) {
@@ -276,6 +288,151 @@ class Block_Search_Command extends WP_CLI_Command {
 		}
 
 		return $assoc_args;
+	}
+
+	/**
+	 * Builds a rough post_content prefilter marker.
+	 *
+	 * The prefilter is advisory only and must never exclude valid matches.
+	 *
+	 * @param string|null $block_name Requested exact block name.
+	 * @param string|null $block_namespace Requested block namespace.
+	 * @param string      $style_name Requested style name.
+	 * @param string|null $pattern_name Requested exact pattern name.
+	 * @param string|null $pattern_namespace Requested pattern namespace.
+	 * @param int|null    $synced_pattern Requested synced pattern post ID.
+	 * @return string[]
+	 */
+	private function build_rough_post_content_prefilter( $block_name, $block_namespace, $style_name, $pattern_name, $pattern_namespace, $synced_pattern ) {
+		$markers = [];
+
+		if ( null !== $block_name && '' !== $block_name ) {
+			$markers[] = '<!-- wp:' . $this->strip_core_block_namespace( $block_name );
+		}
+
+		if ( null !== $block_namespace && '' !== $block_namespace ) {
+			$markers[] = $this->build_block_namespace_prefilter_marker( $block_namespace );
+		}
+
+		if ( '' !== $style_name ) {
+			$markers[] = 'is-style-' . $style_name;
+		}
+
+		if ( null !== $pattern_name && '' !== $pattern_name ) {
+			$markers[] = '"patternName"';
+			$markers[] = $pattern_name;
+		}
+
+		if ( null !== $pattern_namespace && '' !== $pattern_namespace ) {
+			$markers[] = '"patternName"';
+			$markers[] = $pattern_namespace . '/';
+		}
+
+		if ( null !== $synced_pattern ) {
+			$markers[] = '"ref"';
+			$markers[] = (string) $synced_pattern;
+		}
+
+		return array_values( array_unique( $markers ) );
+	}
+
+	/**
+	 * Runs a query with an optional rough post_content prefilter.
+	 *
+	 * @param array    $query_args WP_Query arguments.
+	 * @param string[] $markers Rough prefilter markers.
+	 * @return \WP_Query
+	 */
+	private function run_query_with_rough_prefilter( array $query_args, array $markers ) {
+		if ( [] === $markers ) {
+			return new \WP_Query( $query_args );
+		}
+
+		$query_args['wp_cli_block_search_rough_markers'] = $markers;
+
+		$posts_where = [ $this, 'filter_posts_where_for_rough_post_content_prefilter' ];
+		add_filter( 'posts_where', $posts_where, 10, 2 );
+
+		try {
+			return new \WP_Query( $query_args );
+		} finally {
+			remove_filter( 'posts_where', $posts_where, 10 );
+		}
+	}
+
+	/**
+	 * Applies the rough post_content prefilter to this command's query only.
+	 *
+	 * @param string    $where The WHERE clause.
+	 * @param \WP_Query $query Query instance.
+	 * @return string
+	 */
+	public function filter_posts_where_for_rough_post_content_prefilter( $where, $query ) {
+		global $wpdb;
+
+		$markers = $query->get( 'wp_cli_block_search_rough_markers' );
+
+		if ( ! is_array( $markers ) || [] === $markers ) {
+			return $where;
+		}
+
+		$clauses = [];
+
+		foreach ( $markers as $marker ) {
+			if ( ! is_string( $marker ) || '' === $marker ) {
+				continue;
+			}
+
+			$clauses[] = $wpdb->prepare(
+				"{$wpdb->posts}.post_content LIKE %s",
+				'%' . $wpdb->esc_like( $marker ) . '%'
+			);
+		}
+
+		if ( [] === $clauses ) {
+			return $where;
+		}
+
+		return $where . ' AND ' . implode(
+			' AND ',
+			array_map(
+				static function ( $clause ) {
+					return '(' . $clause . ')';
+				},
+				$clauses
+			)
+		);
+	}
+
+	/**
+	 * Normalizes core block names to their serialized comment marker form.
+	 *
+	 * @param string $block_name Requested exact block name.
+	 * @return string
+	 */
+	private function strip_core_block_namespace( $block_name ) {
+		if ( 0 === strpos( $block_name, 'core/' ) ) {
+			return substr( $block_name, 5 );
+		}
+
+		return $block_name;
+	}
+
+	/**
+	 * Builds a rough serialized comment marker for a block namespace.
+	 *
+	 * Core blocks omit the namespace in serialized comments, so the safest
+	 * coarse marker for core is the generic block comment prefix.
+	 *
+	 * @param string $block_namespace Requested block namespace.
+	 * @return string
+	 */
+	private function build_block_namespace_prefilter_marker( $block_namespace ) {
+		if ( 'core' === $block_namespace ) {
+			return '<!-- wp:';
+		}
+
+		return '<!-- wp:' . $block_namespace . '/';
 	}
 
 	/**

--- a/src/Block_Search_Command.php
+++ b/src/Block_Search_Command.php
@@ -1,0 +1,481 @@
+<?php
+
+namespace WP_CLI\Block;
+
+use WP_CLI;
+use WP_CLI\Formatter;
+use WP_CLI\Utils;
+use WP_CLI_Command;
+
+/**
+ * Searches posts for block usage.
+ *
+ * Returns matching posts where the requested block appears anywhere in the
+ * parsed block tree, including nested blocks.
+ *
+ * ## OPTIONS
+ *
+ * [--block=<block-name>]
+ * : Block type name to search for (for example, 'core/paragraph').
+ *
+ * [--block-namespace=<block-namespace>]
+ * : Limit matches to blocks within a specific namespace (for example, 'core').
+ *
+ * [--style=<style-name>]
+ * : Limit matches to blocks using a specific block style.
+ *
+ * [--pattern=<pattern-name>]
+ * : Limit matches to blocks embedded from a specific pattern (for example, 'twentytwentyfive/event-rsvp').
+ *
+ * [--pattern-namespace=<pattern-namespace>]
+ * : Limit matches to blocks embedded from patterns within a specific namespace (for example, 'twentytwentyfive').
+ *
+ * [--synced-pattern=<post-id>]
+ * : Limit matches to reusable block references for a specific synced pattern post ID.
+ *
+ * [--<field>=<value>]
+ * : One or more args to pass to WP_Query.
+ *
+ * [--field=<field>]
+ * : Prints the value of a single field for each matching post.
+ *
+ * [--fields=<fields>]
+ * : Limit the output to specific result fields.
+ *
+ * [--format=<format>]
+ * : Render output in a particular format.
+ * ---
+ * default: table
+ * options:
+ *   - table
+ *   - csv
+ *   - json
+ *   - count
+ *   - yaml
+ *   - ids
+ * ---
+ *
+ * ## AVAILABLE FIELDS
+ *
+ * These fields will be displayed by default for each matching post:
+ *
+ * * ID
+ * * post_title
+ * * post_name
+ * * post_date
+ * * post_status
+ *
+ * These fields are optionally available:
+ *
+ * * post_type
+ * * url
+ * * occurrences
+ *
+ * ## EXAMPLES
+ *
+ *     # Find posts using the paragraph block.
+ *     $ wp block search --block=core/paragraph
+ *
+ *     # Find any post type posts using the heading block.
+ *     $ wp block search --block=core/heading --post_type=any
+ *
+ *     # Find posts using any block in namespace like 'core'.
+ *     $ wp block search --block-namespace=core
+ *
+ *     # Find posts using any blocks with block style of 'rounded'.
+ *     $ wp block search --style=rounded
+ *
+ *     # Find posts using certain block with a specific style.
+ *     $ wp block search --block=core/image --style=rounded
+ *
+ *     # Search a namespace with a specific style.
+ *     $ wp block search --block-namespace=core --style=rounded
+ *
+ *     # Search published pages for rounded images.
+ *     $ wp block search --block=core/image --style=rounded --post_type=page --post_status=publish
+ *
+ *     # Find posts using blocks embedded from a specific pattern.
+ *     $ wp block search --pattern=twentytwentyfive/event-rsvp
+ *
+ *     # Find posts using blocks from patterns in a specific namespace.
+ *     $ wp block search --pattern-namespace=twentytwentyfive
+ *
+ *     # Find posts using a specific synced pattern.
+ *     $ wp block search --synced-pattern=123
+ *
+ *     # Show selected fields as JSON for further processing.
+ *     $ wp block search --block=core/heading --post_status=publish --fields=ID,post_type,occurrences --format=json
+ *
+ *     # Restrict search to specific posts and return the count.
+ *     $ wp block search --style=rounded --post__in=21,42,84 --format=count
+ *
+ *     # Return only matching post IDs.
+ *     $ wp block search --block=core/paragraph --format=ids
+ *
+ *     # Return count of matching posts.
+ *     $ wp block search --block=core/heading --format=count
+ *
+ * @package wp-cli
+ */
+class Block_Search_Command extends WP_CLI_Command {
+
+	/**
+	 * Searches posts for block usage.
+	 *
+	 * @param array $args Positional arguments. Unused.
+	 * @param array $assoc_args Associative arguments.
+	 */
+	public function __invoke( $args, $assoc_args ) {
+		$block_name      = Utils\get_flag_value( $assoc_args, 'block', null );
+		$block_namespace = Utils\get_flag_value( $assoc_args, 'block-namespace', null );
+		$style_name      = Utils\get_flag_value( $assoc_args, 'style', '' );
+		$pattern_name    = Utils\get_flag_value( $assoc_args, 'pattern', null );
+		$pattern_ns      = Utils\get_flag_value( $assoc_args, 'pattern-namespace', null );
+		$synced_pattern  = Utils\get_flag_value( $assoc_args, 'synced-pattern', null );
+
+		if ( null !== $synced_pattern && '' !== $synced_pattern ) {
+			$synced_pattern = (int) $synced_pattern;
+
+			if ( $synced_pattern <= 0 ) {
+				WP_CLI::error( 'The --synced-pattern parameter must be a positive integer post ID.' );
+			}
+		}
+
+		if ( ( null === $block_name || '' === $block_name ) && ( null === $block_namespace || '' === $block_namespace ) && '' === $style_name && ( null === $pattern_name || '' === $pattern_name ) && ( null === $pattern_ns || '' === $pattern_ns ) && ( null === $synced_pattern || '' === $synced_pattern ) ) {
+			WP_CLI::error( 'At least one block filter is required: --block, --block-namespace, --style, --pattern, --pattern-namespace, or --synced-pattern.' );
+		}
+
+		if ( null !== $block_name && '' !== $block_name && null !== $block_namespace && '' !== $block_namespace ) {
+			WP_CLI::error( 'The --block and --block-namespace parameters are mutually exclusive.' );
+		}
+
+		if ( null !== $pattern_name && '' !== $pattern_name && null !== $pattern_ns && '' !== $pattern_ns ) {
+			WP_CLI::error( 'The --pattern and --pattern-namespace parameters are mutually exclusive.' );
+		}
+
+		$defaults = [
+			'post_type'              => 'any',
+			'post_status'            => 'any',
+			'posts_per_page'         => -1,
+			'no_found_rows'          => true,
+			'cache_results'          => false,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
+		];
+
+		$array_arguments  = [ 'date_query', 'tax_query', 'meta_query' ];
+		$query_assoc_args = Utils\parse_shell_arrays( $assoc_args, $array_arguments );
+
+		unset(
+			$query_assoc_args['block'],
+			$query_assoc_args['block-namespace'],
+			$query_assoc_args['style'],
+			$query_assoc_args['pattern'],
+			$query_assoc_args['pattern-namespace'],
+			$query_assoc_args['synced-pattern'],
+			$query_assoc_args['field'],
+			$query_assoc_args['fields'],
+			$query_assoc_args['format']
+		);
+
+		$query_args = array_merge( $defaults, $query_assoc_args );
+		$query_args = self::process_csv_arguments_to_arrays( $query_args );
+
+		if ( isset( $query_args['post_type'] ) && 'any' !== $query_args['post_type'] ) {
+			$query_args['post_type'] = explode( ',', $query_args['post_type'] );
+		}
+
+		$results = [];
+		$query   = new \WP_Query( $query_args );
+
+		foreach ( $query->posts as $post ) {
+			if ( $this->can_use_has_block_fast_path( $block_name, $block_namespace, $style_name, $pattern_name, $pattern_ns, $synced_pattern ) && ! has_block( $block_name, $post ) ) {
+				continue;
+			}
+
+			$matches = $this->find_matching_blocks( $post->post_content, $block_name, $block_namespace, $style_name, $pattern_name, $pattern_ns, $synced_pattern );
+
+			if ( empty( $matches ) ) {
+				continue;
+			}
+
+			$results[] = [
+				'ID'          => $post->ID,
+				'post_title'  => $post->post_title,
+				'post_name'   => $post->post_name,
+				'post_date'   => $post->post_date,
+				'post_type'   => $post->post_type,
+				'post_status' => $post->post_status,
+				'url'         => get_permalink( $post->ID ),
+				'occurrences' => count( $matches ),
+			];
+		}
+
+		$formatter = new Formatter(
+			$assoc_args,
+			[ 'ID', 'post_title', 'post_name', 'post_date', 'post_status' ],
+			'post'
+		);
+
+		if ( 'ids' === $formatter->format ) {
+			echo implode( ' ', wp_list_pluck( $results, 'ID' ) );
+			return;
+		}
+
+		if ( 'count' === $formatter->format ) {
+			WP_CLI::line( (string) count( $results ) );
+			return;
+		}
+
+		$formatter->display_items( $results );
+	}
+
+	/**
+	 * Converts known CSV query args to arrays for WP_Query compatibility.
+	 *
+	 * @param array $assoc_args Query args.
+	 * @return array
+	 */
+	private static function process_csv_arguments_to_arrays( array $assoc_args ) {
+		$int_array_fields = [
+			'post__in',
+			'post__not_in',
+			'post_parent__in',
+			'post_parent__not_in',
+			'author__in',
+			'author__not_in',
+			'category__in',
+			'category__not_in',
+			'category__and',
+			'tag__in',
+			'tag__not_in',
+			'tag__and',
+		];
+
+		$string_array_fields = [
+			'post_name__in',
+			'tag_slug__in',
+		];
+
+		foreach ( $int_array_fields as $field ) {
+			if ( isset( $assoc_args[ $field ] ) && ! is_array( $assoc_args[ $field ] ) ) {
+				$assoc_args[ $field ] = array_map( 'intval', explode( ',', (string) $assoc_args[ $field ] ) );
+			}
+		}
+
+		foreach ( $string_array_fields as $field ) {
+			if ( isset( $assoc_args[ $field ] ) && ! is_array( $assoc_args[ $field ] ) ) {
+				$assoc_args[ $field ] = array_map( 'trim', explode( ',', (string) $assoc_args[ $field ] ) );
+			}
+		}
+
+		return $assoc_args;
+	}
+
+	/**
+	 * Finds matching blocks in post content.
+	 *
+	 * @param string      $content Post content.
+	 * @param string|null $block_name Requested block name.
+	 * @param string|null $block_namespace Requested block namespace.
+	 * @param string      $style_name Requested style name.
+	 * @param string|null $pattern_name Requested exact pattern name.
+	 * @param string|null $pattern_namespace Requested pattern namespace.
+	 * @param int|null    $synced_pattern Requested synced pattern post ID.
+	 * @return array
+	 */
+	private function find_matching_blocks( $content, $block_name, $block_namespace, $style_name, $pattern_name, $pattern_namespace, $synced_pattern ) {
+		$blocks  = parse_blocks( $content );
+		$matches = [];
+
+		foreach ( $this->flatten_blocks( $blocks ) as $block ) {
+			if ( empty( $block['blockName'] ) ) {
+				continue;
+			}
+
+			if ( ! $this->matches_block_filter( $block['blockName'], $block_name, $block_namespace ) ) {
+				continue;
+			}
+
+			if ( ! $this->matches_pattern_filter( $block, $pattern_name, $pattern_namespace ) ) {
+				continue;
+			}
+
+			if ( ! $this->matches_synced_pattern_filter( $block, $synced_pattern ) ) {
+				continue;
+			}
+
+			if ( ! $this->matches_style_filter( $block, $style_name ) ) {
+				continue;
+			}
+
+			$matches[] = $block;
+		}
+
+		return $matches;
+	}
+
+	/**
+	 * Checks whether an exact block-only search can use has_block() as a fast precheck.
+	 *
+	 * @param string|null $block_name Requested exact block name.
+	 * @param string|null $block_namespace Requested block namespace.
+	 * @param string      $style_name Requested style name.
+	 * @param string|null $pattern_name Requested exact pattern name.
+	 * @param string|null $pattern_namespace Requested pattern namespace.
+	 * @param int|null    $synced_pattern Requested synced pattern post ID.
+	 * @return bool
+	 */
+	private function can_use_has_block_fast_path( $block_name, $block_namespace, $style_name, $pattern_name, $pattern_namespace, $synced_pattern ) {
+		return null !== $block_name
+			&& '' !== $block_name
+			&& ( null === $block_namespace || '' === $block_namespace )
+			&& '' === $style_name
+			&& ( null === $pattern_name || '' === $pattern_name )
+			&& ( null === $pattern_namespace || '' === $pattern_namespace )
+			&& null === $synced_pattern;
+	}
+
+	/**
+	 * Checks whether a parsed block matches the requested block filter.
+	 *
+	 * @param string      $candidate_block_name Parsed block name.
+	 * @param string|null $block_name Requested exact block name.
+	 * @param string|null $block_namespace Requested namespace.
+	 * @return bool
+	 */
+	private function matches_block_filter( $candidate_block_name, $block_name, $block_namespace ) {
+		if ( null !== $block_name && '' !== $block_name ) {
+			return $candidate_block_name === $block_name;
+		}
+
+		if ( null !== $block_namespace && '' !== $block_namespace ) {
+			return 0 === strpos( $candidate_block_name, $block_namespace . '/' );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks whether a parsed block matches the requested pattern filter.
+	 *
+	 * @param array       $block Parsed block.
+	 * @param string|null $pattern_name Requested exact pattern name.
+	 * @param string|null $pattern_namespace Requested pattern namespace.
+	 * @return bool
+	 */
+	private function matches_pattern_filter( array $block, $pattern_name, $pattern_namespace ) {
+		if ( ( null === $pattern_name || '' === $pattern_name ) && ( null === $pattern_namespace || '' === $pattern_namespace ) ) {
+			return true;
+		}
+
+		$ancestor_pattern_name = $this->get_ancestor_pattern_name( $block );
+
+		if ( '' === $ancestor_pattern_name ) {
+			return false;
+		}
+
+		if ( null !== $pattern_name && '' !== $pattern_name ) {
+			return $ancestor_pattern_name === $pattern_name;
+		}
+
+		return 0 === strpos( $ancestor_pattern_name, $pattern_namespace . '/' );
+	}
+
+	/**
+	 * Checks whether a parsed block matches the requested synced pattern filter.
+	 *
+	 * @param array    $block Parsed block.
+	 * @param int|null $synced_pattern Requested synced pattern post ID.
+	 * @return bool
+	 */
+	private function matches_synced_pattern_filter( array $block, $synced_pattern ) {
+		if ( null === $synced_pattern ) {
+			return true;
+		}
+
+		if ( 'core/block' !== $block['blockName'] ) {
+			return false;
+		}
+
+		if ( ! isset( $block['attrs']['ref'] ) ) {
+			return false;
+		}
+
+		return (int) $block['attrs']['ref'] === $synced_pattern;
+	}
+
+	/**
+	 * Gets the nearest pattern name from the block or its inherited ancestor context.
+	 *
+	 * @param array $block Parsed block.
+	 * @return string
+	 */
+	private function get_ancestor_pattern_name( array $block ) {
+		if ( isset( $block['attrs']['metadata']['patternName'] ) && is_string( $block['attrs']['metadata']['patternName'] ) ) {
+			return $block['attrs']['metadata']['patternName'];
+		}
+
+		if ( isset( $block['ancestorPatternName'] ) && is_string( $block['ancestorPatternName'] ) ) {
+			return $block['ancestorPatternName'];
+		}
+
+		return '';
+	}
+
+	/**
+	 * Flattens nested block arrays.
+	 *
+	 * @param array  $blocks Parsed blocks.
+	 * @param string $ancestor_pattern_name Pattern name inherited from the nearest parent wrapper.
+	 * @return array
+	 */
+	private function flatten_blocks( array $blocks, $ancestor_pattern_name = '' ) {
+		$flat_blocks = [];
+
+		foreach ( $blocks as $block ) {
+			$block_pattern_name = $this->get_ancestor_pattern_name( $block );
+
+			if ( '' === $block_pattern_name ) {
+				$block_pattern_name = $ancestor_pattern_name;
+			}
+
+			if ( '' !== $block_pattern_name ) {
+				$block['ancestorPatternName'] = $block_pattern_name;
+			}
+
+			$flat_blocks[] = $block;
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$flat_blocks = array_merge( $flat_blocks, $this->flatten_blocks( $block['innerBlocks'], $block_pattern_name ) );
+			}
+		}
+
+		return $flat_blocks;
+	}
+
+	/**
+	 * Checks whether a parsed block matches the requested style filter.
+	 *
+	 * @param array  $block Parsed block.
+	 * @param string $style_name Requested style name.
+	 * @return bool
+	 */
+	private function matches_style_filter( array $block, $style_name ) {
+		if ( '' === $style_name ) {
+			return true;
+		}
+
+		$class_name = '';
+
+		if ( isset( $block['attrs']['className'] ) && is_string( $block['attrs']['className'] ) ) {
+			$class_name = $block['attrs']['className'];
+		}
+
+		if ( false !== strpos( $class_name, 'is-style-' . $style_name ) ) {
+			return true;
+		}
+
+		return ! empty( $block['innerHTML'] ) && false !== strpos( $block['innerHTML'], 'is-style-' . $style_name );
+	}
+}

--- a/src/Block_Search_Command.php
+++ b/src/Block_Search_Command.php
@@ -453,7 +453,9 @@ class Block_Search_Command extends WP_CLI_Command {
 			$flat_blocks[] = $block;
 
 			if ( ! empty( $block['innerBlocks'] ) ) {
-				$flat_blocks = array_merge( $flat_blocks, $this->flatten_blocks( $block['innerBlocks'], $block_pattern_name ) );
+				foreach ( $this->flatten_blocks( $block['innerBlocks'], $block_pattern_name ) as $inner_block ) {
+					$flat_blocks[] = $inner_block;
+				}
 			}
 		}
 

--- a/src/Block_Search_Command.php
+++ b/src/Block_Search_Command.php
@@ -453,9 +453,7 @@ class Block_Search_Command extends WP_CLI_Command {
 			$flat_blocks[] = $block;
 
 			if ( ! empty( $block['innerBlocks'] ) ) {
-				foreach ( $this->flatten_blocks( $block['innerBlocks'], $block_pattern_name ) as $inner_block ) {
-					$flat_blocks[] = $inner_block;
-				}
+				$flat_blocks = array_merge( $flat_blocks, $this->flatten_blocks( $block['innerBlocks'], $block_pattern_name ) );
 			}
 		}
 
@@ -480,10 +478,14 @@ class Block_Search_Command extends WP_CLI_Command {
 			$class_name = $block['attrs']['className'];
 		}
 
-		if ( false !== strpos( $class_name, 'is-style-' . $style_name ) ) {
+		$needle = 'is-style-' . $style_name;
+		if ( 1 === preg_match( '/(^|\\s)' . preg_quote( $needle, '/' ) . '(\\s|$)/', $class_name ) ) {
 			return true;
 		}
 
-		return ! empty( $block['innerHTML'] ) && false !== strpos( $block['innerHTML'], 'is-style-' . $style_name );
+		return ! empty( $block['innerHTML'] ) && 1 === preg_match(
+			"/(^|[\\s\"'])" . preg_quote( $needle, '/' ) . "([\\s\"']|$)/",
+			$block['innerHTML']
+		);
 	}
 }

--- a/src/Block_Search_Command.php
+++ b/src/Block_Search_Command.php
@@ -39,7 +39,7 @@ use WP_CLI_Command;
  *   Use native WP_Query pagination args `--posts_per_page=<n>` and
  *   `--paged=<n>` to scan large sites in smaller batches. These args limit the
  *   candidate posts examined for a given run; they do not add pagination
- *   metadata to the command output. Results in each page may not be equal and empty response isn't quarantee that next page won't have results.
+ *   metadata to the command output. Results in each page may not be equal and empty response isn't guarantee that next page won't have results.
  *
  * [--field=<field>]
  * : Prints the value of a single field for each matching post.

--- a/src/Block_Search_Command.php
+++ b/src/Block_Search_Command.php
@@ -36,6 +36,11 @@ use WP_CLI_Command;
  * [--<field>=<value>]
  * : One or more args to pass to WP_Query.
  *
+ *   Use native WP_Query pagination args `--posts_per_page=<n>` and
+ *   `--paged=<n>` to scan large sites in smaller batches. These args limit the
+ *   candidate posts examined for a given run; they do not add pagination
+ *   metadata to the command output. Results in each page may not be equal and empty response isn't quarantee that next page won't have results.
+ *
  * [--field=<field>]
  * : Prints the value of a single field for each matching post.
  *
@@ -108,6 +113,9 @@ use WP_CLI_Command;
  *
  *     # Limit the candidate posts scanned with a native query argument.
  *     $ wp block search --block=core/paragraph --showposts=50 --format=ids
+ *
+ *     # Scan the second batch of 1000 candidate posts without changing output format.
+ *     $ wp block search --block=core/paragraph --posts_per_page=1000 --paged=2 --format=ids
  *
  *     # Restrict search to specific posts and return the count.
  *     $ wp block search --style=rounded --post__in=21,42,84 --format=count

--- a/src/Block_Search_Command.php
+++ b/src/Block_Search_Command.php
@@ -131,17 +131,19 @@ class Block_Search_Command extends WP_CLI_Command {
 		$style_name      = Utils\get_flag_value( $assoc_args, 'style', '' );
 		$pattern_name    = Utils\get_flag_value( $assoc_args, 'pattern', null );
 		$pattern_ns      = Utils\get_flag_value( $assoc_args, 'pattern-namespace', null );
-		$synced_pattern  = Utils\get_flag_value( $assoc_args, 'synced-pattern', null );
+		$synced_pattern  = null;
 
-		if ( null !== $synced_pattern && '' !== $synced_pattern ) {
-			$synced_pattern = (int) $synced_pattern;
+		$synced_pattern_raw = Utils\get_flag_value( $assoc_args, 'synced-pattern', null );
+
+		if ( null !== $synced_pattern_raw && '' !== $synced_pattern_raw ) {
+			$synced_pattern = (int) $synced_pattern_raw;
 
 			if ( $synced_pattern <= 0 ) {
 				WP_CLI::error( 'The --synced-pattern parameter must be a positive integer post ID.' );
 			}
 		}
 
-		if ( ( null === $block_name || '' === $block_name ) && ( null === $block_namespace || '' === $block_namespace ) && '' === $style_name && ( null === $pattern_name || '' === $pattern_name ) && ( null === $pattern_ns || '' === $pattern_ns ) && ( null === $synced_pattern || '' === $synced_pattern ) ) {
+		if ( ( null === $block_name || '' === $block_name ) && ( null === $block_namespace || '' === $block_namespace ) && '' === $style_name && ( null === $pattern_name || '' === $pattern_name ) && ( null === $pattern_ns || '' === $pattern_ns ) && null === $synced_pattern ) {
 			WP_CLI::error( 'At least one block filter is required: --block, --block-namespace, --style, --pattern, --pattern-namespace, or --synced-pattern.' );
 		}
 
@@ -189,6 +191,10 @@ class Block_Search_Command extends WP_CLI_Command {
 		$query   = new \WP_Query( $query_args );
 
 		foreach ( $query->posts as $post ) {
+			if ( ! $post instanceof \WP_Post ) {
+				continue;
+			}
+
 			if ( $this->can_use_has_block_fast_path( $block_name, $block_namespace, $style_name, $pattern_name, $pattern_ns, $synced_pattern ) && ! has_block( $block_name, $post ) ) {
 				continue;
 			}


### PR DESCRIPTION
# Summary

This PR adds a new `wp block search` command to the `block-command` package.

The command searches posts for block usage across parsed block trees, including nested blocks, and supports multiple filter types:

- exact block name with `--block`
- block namespace with `--block-namespace`
- block style with `--style`
- embedded pattern name with `--pattern`
- embedded pattern namespace with `--pattern-namespace`
- synced pattern reference by reusable block post ID with `--synced-pattern`

The command returns matching posts and supports the standard WP-CLI output formats such as `table`, `json`, `csv`, `yaml`, `count`, and `ids`.

# Why

Block usage is a common operational and migration concern in block-based sites.

Typical use cases include:

- finding all content that uses a specific block before changing or removing it
- performing design review for blocks or patterns based on real content
- finding out obsolete blocks, patterns or block styles
- identifying posts using a specific block style such as `is-style-rounded`
- locating content that references a specific synced pattern / reusable block
- narrowing searches to a post type, post status, ID set, or other `WP_Query` constraints
- exporting results for downstream reporting or scripted migrations

Before this change, users could inspect blocks indirectly, but there was no dedicated command in `block-command` for querying content by block usage.

# Command Design

The command lives under `wp block search`, which is the natural home for block-related content inspection. Alternative option was under `wp post` but as that is more directed on handling singular post data, this is more fitting.

Supported filters:

- `--block=<name>` for exact block matching such as `core/image`
- `--block-namespace=<namespace>` for namespace-level searches such as `core`
- `--style=<style-name>` for block style matching such as `outline`
- `--pattern=<pattern-name>` for exact embedded pattern matching via `metadata.patternName` such as `twentytwentyfive/event-rsvp`
- `--pattern-namespace=<namespace>` for embedded pattern namespace matching such as `twentytwentyfive`
- `--synced-pattern=<post-id>` for `core/block` references pointing at a reusable block / synced pattern ID

Validation rules:

- at least one search filter is required
- `--block` and `--block-namespace` are mutually exclusive
- `--pattern` and `--pattern-namespace` are mutually exclusive
- `--synced-pattern` must be a positive integer

# Technical Choices And Rationale

## Parse blocks instead of relying on raw SQL or string matching

The command uses `parse_blocks()` and walks the parsed tree rather than trying to inspect post content with string matching or SQL.

Rationale:

- block structure is nested and semantic
- styles and metadata live in parsed attributes, not only in plain text patterns
- the command needs accurate occurrence counting
- the command needs to support combinations of block, style, pattern, and synced-pattern filters

Exception:

- For searching only with block filter, we use `has_block()` that avoids running `parse_blocks()` for better performance.

## Keep pattern matching and synced pattern matching separate

Embedded patterns and synced patterns are different concepts and are stored differently.

- embedded patterns are detected via block metadata, specifically `metadata.patternName`
- synced patterns are detected via `core/block` with a `ref` attribute pointing to a `wp_block` post

Rationale:

- avoids overloading a single flag with multiple meanings
- keeps the command contract explicit for users
- makes validation and implementation easier to reason about

## Preserve nearest pattern ancestor context when flattening nested blocks

The command flattens parsed blocks for matching, but nested block searches need pattern ancestry to remain available.

Example:

- a wrapper block may carry `metadata.patternName`
- a child block may carry the actual `blockName` or style being searched

Without inherited ancestor pattern context, a combined search like `--pattern-namespace=twentytwentyfive --block=core/image` would fail for nested images inside a pattern wrapper.

The implementation therefore carries the nearest ancestor pattern name onto descendants during flattening.

Rationale:

- fixes combined block + pattern searches for nested content
- correctly handles patterns nested inside patterns by preferring the nearest ancestor
- keeps the later matcher simple and local per flattened node

## Add a cheap `has_block()` fast path for exact block-only searches

For the narrow case where the search is only `--block=<exact-name>`, the command uses `has_block()` as a cheap precheck before parsing blocks.

Rationale:

- avoids unnecessary `parse_blocks()` work for posts that clearly do not contain the requested block
- does not affect more complex searches involving namespace, style, pattern, or synced-pattern filters
- keeps the optimization safe by limiting it to the exact block-only case

## Use constrained `WP_Query` defaults for large scans

The command uses:

- `no_found_rows => true`
- `cache_results => false`
- `update_post_meta_cache => false`
- `update_post_term_cache => false`

Rationale:

- reduces overhead for read-only search workloads
- avoids unnecessary object cache churn when scanning many posts
- fits the command’s usage pattern, where result hydration beyond the loaded posts is not needed

# Usage Examples

Find posts using a specific block:

```bash
wp block search --block=core/paragraph
```

Find posts using any block from a namespace:

```bash
wp block search --block-namespace=core
```

Limit the search to a specific post type:

```bash
wp block search --block=core/image --post_type=page
```

Find posts using a specific style:

```bash
wp block search --style=rounded
```

Combine block and style filters:

```bash
wp block search --block=core/image --style=rounded
```

Find posts using blocks embedded from a specific pattern:

```bash
wp block search --pattern=twentytwentyfive/event-rsvp
```

Find posts using blocks from patterns in a namespace:

```bash
wp block search --pattern-namespace=twentytwentyfive
```

Find images that appear inside a specific pattern namespace:

```bash
wp block search --pattern-namespace=twentytwentyfive --block=core/image
```

Find posts that reference a synced pattern / reusable block:

```bash
wp block search --synced-pattern=123
```

Return JSON output for automation:

```bash
wp block search --block=core/heading --post_status=publish --fields=ID,post_type,occurrences --format=json
```

Return permalinks for matching posts:

```bash
wp block search --block=core/quote --fields=url --format=csv
```

Return only the count:

```bash
wp block search --style=rounded --format=count
```

# Testing

Acceptance coverage was added for:

- exact block matching
- namespace matching
- nested block matching
- style matching
- count output
- IDs output
- JSON output with occurrences
- exact embedded pattern matching
- embedded pattern namespace matching
- combined pattern + block matching
- nearest-ancestor behavior for patterns nested inside patterns
- synced pattern reference matching
- validation errors for incompatible or missing parameters

# Notes

- `metadata.patternName` has not been around in patterns since their introduction. This means pattern search may not find all patterns where they are added before core introduced this meta.
- `--synced-pattern` is intentionally exact-only and currently accepts a single post ID.
- pattern filters and synced pattern filters are intentionally separate to keep the CLI contract clear.
- the command is designed for accuracy first, with scoped optimizations where they are safe.

# Related issues

- Implements https://github.com/wp-cli/ideas/issues/212
- Implements https://github.com/wp-cli/ideas/issues/214
- Lays base for https://github.com/wp-cli/ideas/issues/213 and https://github.com/wp-cli/ideas/issues/215 (these could become `wp block search summary` or similar)

# Acknowledgements

Thanks to @janw-me and @schlessera for guidance during WCEU 2026. The scope, naming and structure was refined greatly with them.